### PR TITLE
do not chmod user's bin

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,8 +14,8 @@ ls $_THEMES_DIR 2> /dev/null || mkdir -p $_THEMES_DIR
 cp -r CatalinaDynamic $_THEMES_DIR
 
 # Copy scripts
-cp -r bin ${HOME}
-chmod +x ${HOME}/bin/*
+chmod +x ./bin/*
+cp -r ./bin ${HOME}
 
 # Start it.
 ${HOME}/bin/catalina --start


### PR DESCRIPTION
You chmoded after the scripts were copied. This is bad in case somebody, crazy, like me, has a script under bin that they don't have executable for, whatever reason such as crawling out in the dead of night.